### PR TITLE
Allow all hosts for development

### DIFF
--- a/glidepath_project/settings.py
+++ b/glidepath_project/settings.py
@@ -4,7 +4,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = 'django-insecure-replace-this'
 DEBUG = True
-ALLOWED_HOSTS: list[str] = []
+ALLOWED_HOSTS: list[str] = ["*"]
 
 INSTALLED_APPS = [
     'django.contrib.contenttypes',


### PR DESCRIPTION
## Summary
- Permit any host in Django `ALLOWED_HOSTS` to avoid DisallowedHost errors when accessing remotely

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<5.0,>=4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4941de38832ead4edd156f7b62bc