### PR TITLE
Add HTMX-powered charts with Tailwind and Chart.js

### DIFF
--- a/glidepath_app/static/glidepath_app/chartAdapter.js
+++ b/glidepath_app/static/glidepath_app/chartAdapter.js
@@ -1,0 +1,17 @@
+(function () {
+    window.chartAdapter = {
+        init: function (ctx, config) {
+            return new Chart(ctx, config);
+        },
+        update: function (chart, config) {
+            chart.config.data = config.data;
+            if (config.options) {
+                chart.config.options = config.options;
+            }
+            chart.update();
+        },
+        destroy: function (chart) {
+            chart.destroy();
+        }
+    };
+})();

--- a/glidepath_app/templates/glidepath_app/base.html
+++ b/glidepath_app/templates/glidepath_app/base.html
@@ -1,0 +1,16 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}Glidepath{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.9"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="{% static 'glidepath_app/chartAdapter.js' %}"></script>
+</head>
+<body class="p-4">
+    {% block content %}{% endblock %}
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/glidepath_app/templates/glidepath_app/rules.html
+++ b/glidepath_app/templates/glidepath_app/rules.html
@@ -1,0 +1,75 @@
+<div class="overflow-x-auto">
+    <table class="min-w-full border">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="px-2 py-1 border">gt-retire-age</th>
+                <th class="px-2 py-1 border">lt-retire-age</th>
+                <th class="px-2 py-1 border">Classes</th>
+                <th class="px-2 py-1 border">Categories</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for rule in rules %}
+            <tr class="odd:bg-white even:bg-gray-50">
+                <td class="px-2 py-1 border">{{ rule.gt_retire_age }}</td>
+                <td class="px-2 py-1 border">{{ rule.lt_retire_age }}</td>
+                <td class="px-2 py-1 border">
+                    {% for ca in rule.class_allocations.all %}
+                        {{ ca.asset_class.name }}: {{ ca.percentage }}%<br>
+                    {% endfor %}
+                </td>
+                <td class="px-2 py-1 border">
+                    {% for ca in rule.category_allocations.all %}
+                        {{ ca.asset_category.asset_class.name }}:{{ ca.asset_category.name }}: {{ ca.percentage }}%<br>
+                    {% endfor %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+<div class="mt-8">
+    <canvas id="classChart"></canvas>
+</div>
+<div class="mt-8">
+    <canvas id="categoryChart"></canvas>
+</div>
+<script>
+(function() {
+    if (window.classChart) {
+        chartAdapter.destroy(window.classChart);
+    }
+    if (window.categoryChart) {
+        chartAdapter.destroy(window.categoryChart);
+    }
+    const retirePlugin = {
+        id: 'retireLine',
+        afterDraw(chart) {
+            const index = chart.data.labels.indexOf('0');
+            if (index !== -1) {
+                const x = chart.scales.x.getPixelForValue(index);
+                const ctx = chart.ctx;
+                ctx.save();
+                ctx.strokeStyle = 'red';
+                ctx.beginPath();
+                ctx.moveTo(x, chart.chartArea.top);
+                ctx.lineTo(x, chart.chartArea.bottom);
+                ctx.stroke();
+                ctx.restore();
+            }
+        }
+    };
+    const commonOpts = {
+        plugins: { legend: { position: 'bottom' } },
+        scales: { x: { stacked: true }, y: { stacked: true, ticks: { callback: v => v + '%' } } }
+    };
+    window.classChart = chartAdapter.init(
+        document.getElementById('classChart').getContext('2d'),
+        { type: 'bar', data: {{ class_chart|safe }}, options: commonOpts, plugins:[retirePlugin] }
+    );
+    window.categoryChart = chartAdapter.init(
+        document.getElementById('categoryChart').getContext('2d'),
+        { type: 'bar', data: {{ category_chart|safe }}, options: commonOpts, plugins:[retirePlugin] }
+    );
+})();
+</script>

--- a/glidepath_app/templates/glidepath_app/upload.html
+++ b/glidepath_app/templates/glidepath_app/upload.html
@@ -1,61 +1,32 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Glidepath Rules</title>
-</head>
-<body>
-<h1>Glidepath Rules</h1>
+{% extends 'glidepath_app/base.html' %}
+{% block title %}Glidepath Rules{% endblock %}
+{% block content %}
+<h1 class="text-2xl mb-4">Glidepath Rules</h1>
 {% if error %}
-<p style="color:red;">{{ error }}</p>
+<p class="text-red-500">{{ error }}</p>
 {% endif %}
-<form method="get">
-    <select name="ruleset" onchange="this.form.submit()">
+<form method="get" class="mb-4">
+    <select name="ruleset" class="border p-1" hx-get="{% url 'home' %}" hx-target="#rules" hx-trigger="change">
         {% for rs in rule_sets %}
             <option value="{{ rs.id }}" {% if selected_set and rs.id == selected_set.id %}selected{% endif %}>{{ rs.name }}</option>
         {% endfor %}
     </select>
-    <noscript><button type="submit">View</button></noscript>
+    <noscript><button type="submit" class="ml-2 px-2 py-1 bg-blue-500 text-white">View</button></noscript>
 </form>
-<form method="post" style="display:inline;">
+<form method="post" style="display:inline;" class="mr-2">
     {% csrf_token %}
     <input type="hidden" name="delete" value="{{ selected_set.id }}">
-    <button type="submit" {% if not selected_set %}disabled{% endif %}>Delete</button>
+    <button type="submit" class="px-2 py-1 bg-red-500 text-white" {% if not selected_set %}disabled{% endif %}>Delete</button>
 </form>
-<form method="post" enctype="multipart/form-data">
+<form method="post" enctype="multipart/form-data" class="inline">
     {% csrf_token %}
-    <input type="file" name="file" required>
-    <button type="submit">Upload</button>
+    <input type="file" name="file" required class="border p-1">
+    <button type="submit" class="px-2 py-1 bg-green-500 text-white">Upload</button>
 </form>
 {% if selected_set %}
-<p><a href="{% url 'export_rules' %}?ruleset={{ selected_set.id }}">Export CSV</a></p>
+<p class="mt-2"><a class="text-blue-600 underline" href="{% url 'export_rules' %}?ruleset={{ selected_set.id }}">Export CSV</a></p>
 {% endif %}
-<table border="1">
-    <thead>
-        <tr>
-            <th>gt-retire-age</th>
-            <th>lt-retire-age</th>
-            <th>Classes</th>
-            <th>Categories</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for rule in rules %}
-        <tr>
-            <td>{{ rule.gt_retire_age }}</td>
-            <td>{{ rule.lt_retire_age }}</td>
-            <td>
-                {% for ca in rule.class_allocations.all %}
-                    {{ ca.asset_class.name }}: {{ ca.percentage }}%<br>
-                {% endfor %}
-            </td>
-            <td>
-                {% for ca in rule.category_allocations.all %}
-                    {{ ca.asset_category.asset_class.name }}:{{ ca.asset_category.name }}: {{ ca.percentage }}%<br>
-                {% endfor %}
-            </td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-</body>
-</html>
+<div id="rules" class="mt-4">
+    {% include 'glidepath_app/rules.html' %}
+</div>
+{% endblock %}

--- a/glidepath_app/views.py
+++ b/glidepath_app/views.py
@@ -1,9 +1,101 @@
+import json
+
 from django.http import HttpResponse
 from django.shortcuts import render
 
 from .forms import GlidepathRuleUploadForm
 from .models import GlidepathRule, RuleSet
 from .services import export_glidepath_rules, import_glidepath_rules
+
+BASE_COLORS = [
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+]
+
+
+def _lighten(color: str, factor: float) -> str:
+    """Lighten a hex color by the given factor (0-1)."""
+    color = color.lstrip("#")
+    r = int(color[0:2], 16)
+    g = int(color[2:4], 16)
+    b = int(color[4:6], 16)
+    r = int(r + (255 - r) * factor)
+    g = int(g + (255 - g) * factor)
+    b = int(b + (255 - b) * factor)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _build_chart_data(rules):
+    rules_sorted = sorted(rules, key=lambda r: r.gt_retire_age)
+    chart_rules: list[tuple[str, GlidepathRule]] = []
+    without_placeholder = [r for r in rules_sorted if r.gt_retire_age != -100]
+    if rules_sorted and rules_sorted[0].gt_retire_age == -100:
+        chart_rules.append(("earlier", rules_sorted[0]))
+    for r in without_placeholder:
+        chart_rules.append((str(r.gt_retire_age), r))
+    if without_placeholder:
+        chart_rules.append(("later", without_placeholder[-1]))
+    labels = [lbl for lbl, _ in chart_rules]
+
+    class_names: list[str] = []
+    for r in rules:
+        for ca in r.class_allocations.all():
+            name = ca.asset_class.name
+            if name not in class_names:
+                class_names.append(name)
+
+    class_datasets = []
+    for idx, name in enumerate(class_names):
+        color = BASE_COLORS[idx % len(BASE_COLORS)]
+        data = []
+        for _, rule in chart_rules:
+            perc = 0.0
+            for ca in rule.class_allocations.all():
+                if ca.asset_class.name == name:
+                    perc = float(ca.percentage)
+                    break
+            data.append(perc)
+        class_datasets.append({"label": name, "data": data, "backgroundColor": color})
+
+    category_datasets = []
+    for class_idx, class_name in enumerate(class_names):
+        cat_names: list[str] = []
+        for r in rules:
+            for ca in r.category_allocations.all():
+                if ca.asset_category.asset_class.name == class_name:
+                    cname = ca.asset_category.name
+                    if cname not in cat_names:
+                        cat_names.append(cname)
+        base_color = BASE_COLORS[class_idx % len(BASE_COLORS)]
+        count = len(cat_names)
+        for j, cname in enumerate(cat_names):
+            color = _lighten(base_color, 0.2 + 0.6 * j / max(1, count))
+            data = []
+            for _, rule in chart_rules:
+                perc = 0.0
+                for ca in rule.category_allocations.all():
+                    if (
+                        ca.asset_category.name == cname
+                        and ca.asset_category.asset_class.name == class_name
+                    ):
+                        perc = float(ca.percentage)
+                        break
+                data.append(perc)
+            category_datasets.append(
+                {"label": cname, "data": data, "backgroundColor": color}
+            )
+
+    class_chart = {"labels": labels, "datasets": class_datasets}
+    category_chart = {"labels": labels, "datasets": category_datasets}
+    return class_chart, category_chart
 
 
 def upload_rules(request):
@@ -40,17 +132,22 @@ def upload_rules(request):
         "category_allocations__asset_category__asset_class",
     )
 
-    return render(
-        request,
-        "glidepath_app/upload.html",
-        {
-            "form": form,
-            "error": error,
-            "rules": rules,
-            "rule_sets": rule_sets,
-            "selected_set": selected_set,
-        },
-    )
+    class_chart, category_chart = _build_chart_data(list(rules))
+
+    context = {
+        "form": form,
+        "error": error,
+        "rules": rules,
+        "rule_sets": rule_sets,
+        "selected_set": selected_set,
+        "class_chart": json.dumps(class_chart),
+        "category_chart": json.dumps(category_chart),
+    }
+
+    template = "glidepath_app/upload.html"
+    if request.headers.get("HX-Request"):
+        template = "glidepath_app/rules.html"
+    return render(request, template, context)
 
 
 def export_rules(request):


### PR DESCRIPTION
## Summary
- Introduce Tailwind, HTMX and Chart.js via a base template and chart adapter
- Render rules table with HTMX partial including stacked bar charts for classes and categories
- Build chart data in view with color helpers and earlier/later age labels

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b3acd984832e94de1fd957276816