### PR TITLE
Prevent chartAdapter from calling missing destroy

### DIFF
--- a/glidepath_app/static/glidepath_app/chartAdapter.js
+++ b/glidepath_app/static/glidepath_app/chartAdapter.js
@@ -11,7 +11,9 @@
             chart.update();
         },
         destroy: function (chart) {
-            chart.destroy();
+            if (chart && typeof chart.destroy === 'function') {
+                chart.destroy();
+            }
         }
     };
 })();


### PR DESCRIPTION
## Summary
- safely destroy charts in chartAdapter

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b0db1a6e58832eb73c0118ce395d3a