### PR TITLE
Fix chart resizing on ruleset change

### DIFF
--- a/glidepath_app/templates/glidepath_app/rules.html
+++ b/glidepath_app/templates/glidepath_app/rules.html
@@ -28,14 +28,16 @@
         </tbody>
     </table>
 </div>
-<div class="mt-8">
-    <canvas id="classChart"></canvas>
-</div>
-<div class="mt-8">
-    <canvas id="categoryChart"></canvas>
-</div>
-<div class="mt-8">
-    <canvas id="classPieChart"></canvas>
+<div class="mt-8 flex flex-wrap justify-center gap-4">
+    <div class="w-full max-w-[50vw] md:w-1/2 lg:w-1/3 h-[33vh]">
+        <canvas id="classChart" class="w-full h-full"></canvas>
+    </div>
+    <div class="w-full max-w-[50vw] md:w-1/2 lg:w-1/3 h-[33vh]">
+        <canvas id="categoryChart" class="w-full h-full"></canvas>
+    </div>
+    <div class="w-full max-w-[50vw] md:w-1/2 lg:w-1/3 h-[33vh]">
+        <canvas id="classPieChart" class="w-full h-full"></canvas>
+    </div>
 </div>
 <script>
 if (window._renderChartsCallback) {
@@ -84,7 +86,9 @@ window._renderChartsCallback = function () {
     };
     const commonOpts = {
         plugins: { legend: { position: 'bottom' }, tooltip },
-        scales: { x: { stacked: true }, y: { stacked: true, ticks: { callback: v => v + '%' } } }
+        scales: { x: { stacked: true }, y: { stacked: true, ticks: { callback: v => v + '%' } } },
+        responsive: true,
+        maintainAspectRatio: false
     };
     window.classChart = chartAdapter.init(
         classCanvas.getContext('2d'),
@@ -102,7 +106,9 @@ window._renderChartsCallback = function () {
                     label: ctx => `${ctx.label}: ${ctx.parsed}%`
                 }
             }
-        }
+        },
+        responsive: true,
+        maintainAspectRatio: false
     };
     window.classPieChart = chartAdapter.init(
         pieCanvas.getContext('2d'),


### PR DESCRIPTION
## Summary
- keep charts within viewport via responsive Tailwind layout
- lock chart aspect ratio and responsive sizing so they don't expand when changing rulesets

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f281fbf8832e85d1bd6338ce43a2