### PR TITLE
Fix KeyError when adding new identity provider

### DIFF
--- a/glidepath_app/forms.py
+++ b/glidepath_app/forms.py
@@ -270,8 +270,8 @@ class IdentityProviderForm(forms.ModelForm):
         labels = {
             'name': 'Provider Name',
             'type': 'Provider Type',
-            'redirect_url': 'Redirect URL',
             'auto_provision_users': 'Auto Provision Users',
+            'disabled': 'Disabled',
             'client_id': 'Client ID',
             'client_secret': 'Client Secret',
             'authorization_url': 'Authorization URL',
@@ -285,7 +285,6 @@ class IdentityProviderForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['name_path'].required = False
-        self.fields['redirect_url'].required = False
 
 
 class PortfolioForm(forms.ModelForm):


### PR DESCRIPTION
The IdentityProviderForm __init__ method was trying to access self.fields['redirect_url'] which no longer exists since redirect_url was removed from the form fields (it's now system-generated).

Also removed the stale 'redirect_url' label and added 'disabled' label.

Fixes the KeyError that occurred when accessing /settings/identity-providers/add/