### PR TITLE
Phase 5: admin CRUD for virtual funds + provider price refresh

### DIFF
--- a/glidepath_app/forms.py
+++ b/glidepath_app/forms.py
@@ -1,6 +1,14 @@
+from decimal import Decimal
 from django import forms
-from .models import APISettings, Fund, AssetCategory, User, IdentityProvider, AccountUpload, Portfolio, RuleSet, AssumptionUpload, SessionSettings
+from .models import (
+    APISettings, Fund, AssetCategory, User, IdentityProvider, AccountUpload,
+    Portfolio, RuleSet, AssumptionUpload, SessionSettings,
+    FundProvider, VirtualFund, VirtualFundComposition,
+)
 from django.contrib.auth.hashers import make_password
+
+
+_INPUT = 'w-full border border-gray-300 rounded-md p-2'
 
 
 class GlidepathRuleUploadForm(forms.Form):
@@ -442,3 +450,88 @@ class SessionSettingsForm(forms.ModelForm):
         help_texts = {
             'session_timeout_minutes': 'Time before an inactive session expires (1-43200 minutes). Default: 360 (6 hours)',
         }
+
+
+class FundProviderForm(forms.ModelForm):
+    """Add/edit a virtual-fund provider (e.g. a 529 plan)."""
+
+    class Meta:
+        model = FundProvider
+        fields = ['name', 'slug', 'price_source_url', 'price_scraper', 'notes']
+        widgets = {
+            'name': forms.TextInput(attrs={'class': _INPUT, 'placeholder': 'NY 529 Direct Plan'}),
+            'slug': forms.TextInput(attrs={'class': _INPUT, 'placeholder': 'nysaves'}),
+            'price_source_url': forms.URLInput(attrs={'class': _INPUT, 'placeholder': 'https://...'}),
+            'price_scraper': forms.TextInput(attrs={'class': _INPUT, 'placeholder': 'nysaves'}),
+            'notes': forms.Textarea(attrs={'class': _INPUT, 'rows': 2}),
+        }
+        labels = {
+            'price_source_url': 'Price Source URL',
+            'price_scraper': 'Scraper Identifier',
+        }
+        help_texts = {
+            'slug': 'Stable identifier used in URLs and uploads (e.g. nysaves).',
+            'price_scraper': 'Scraper key dispatched by scraper_service (e.g. nysaves). Leave blank if no scraper.',
+        }
+
+
+class VirtualFundForm(forms.ModelForm):
+    """Add/edit a virtual fund and its current price."""
+
+    class Meta:
+        model = VirtualFund
+        fields = ['provider', 'name', 'slug', 'unit_price', 'price_as_of', 'is_active', 'notes']
+        widgets = {
+            'provider': forms.Select(attrs={'class': _INPUT}),
+            'name': forms.TextInput(attrs={'class': _INPUT, 'placeholder': 'Growth Stock Index Portfolio'}),
+            'slug': forms.TextInput(attrs={'class': _INPUT, 'placeholder': 'growth-stock-index'}),
+            'unit_price': forms.NumberInput(attrs={'class': _INPUT, 'step': '0.0001'}),
+            'price_as_of': forms.DateInput(attrs={'class': _INPUT, 'type': 'date'}),
+            'is_active': forms.CheckboxInput(attrs={'class': 'ml-2'}),
+            'notes': forms.Textarea(attrs={'class': _INPUT, 'rows': 2}),
+        }
+        labels = {
+            'unit_price': 'Unit Price',
+            'price_as_of': 'Price As Of',
+            'is_active': 'Active',
+        }
+        help_texts = {
+            'slug': 'Unique per provider; used as the position symbol for uploads.',
+        }
+
+
+class BaseCompositionFormSet(forms.BaseInlineFormSet):
+    """Inline formset enforcing that a virtual fund's composition sums to 100%."""
+
+    def clean(self):
+        super().clean()
+        if any(self.errors):
+            return
+        total = Decimal('0')
+        rows = 0
+        for form in self.forms:
+            cd = getattr(form, 'cleaned_data', None)
+            if not cd or cd.get('DELETE'):
+                continue
+            if cd.get('asset_category') is None and cd.get('percentage') is None:
+                continue
+            rows += 1
+            total += cd.get('percentage') or Decimal('0')
+        if rows and total != Decimal('100'):
+            raise forms.ValidationError(
+                f"Composition percentages must sum to 100% (currently {total}%)."
+            )
+
+
+VirtualFundCompositionFormSet = forms.inlineformset_factory(
+    VirtualFund,
+    VirtualFundComposition,
+    formset=BaseCompositionFormSet,
+    fields=['asset_category', 'percentage'],
+    widgets={
+        'asset_category': forms.Select(attrs={'class': _INPUT}),
+        'percentage': forms.NumberInput(attrs={'class': _INPUT, 'step': '0.01'}),
+    },
+    extra=1,
+    can_delete=True,
+)

--- a/glidepath_app/forms.py
+++ b/glidepath_app/forms.py
@@ -516,7 +516,9 @@ class BaseCompositionFormSet(forms.BaseInlineFormSet):
             if cd.get('asset_category') is None and cd.get('percentage') is None:
                 continue
             rows += 1
-            total += cd.get('percentage') or Decimal('0')
+            pct = cd.get('percentage')
+            if pct is not None:  # Decimal('0') is falsy — don't use `or`
+                total += pct
         if rows and total != Decimal('100'):
             raise forms.ValidationError(
                 f"Composition percentages must sum to 100% (currently {total}%)."

--- a/glidepath_app/scraper_service.py
+++ b/glidepath_app/scraper_service.py
@@ -159,8 +159,12 @@ def refresh_virtual_fund_prices(provider_slug: str) -> dict:
             provider_slug, len(unmatched_scraped), ", ".join(sorted(unmatched_scraped)),
         )
 
-    provider.last_price_refresh = timezone.now()
-    provider.save(update_fields=["last_price_refresh"])
+    # Only stamp last_price_refresh when prices were actually retrieved. A run that
+    # updates nothing (scrape returned nothing / matched no fund) is not treated as a
+    # successful fetch, so callers throttling on this timestamp allow an immediate retry.
+    if updated_funds:
+        provider.last_price_refresh = timezone.now()
+        provider.save(update_fields=["last_price_refresh"])
 
     return {
         "updated": len(updated_funds),

--- a/glidepath_app/templates/glidepath_app/base.html
+++ b/glidepath_app/templates/glidepath_app/base.html
@@ -30,6 +30,9 @@
                         <a href="{% url 'funds' %}" class="{% if request.resolver_match.url_name == 'funds' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700{% endif %} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
                             Funds
                         </a>
+                        <a href="{% url 'virtual_funds' %}" class="{% if request.resolver_match.url_name == 'virtual_funds' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700{% endif %} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
+                            Virtual Funds
+                        </a>
                         <a href="{% url 'assumptions' %}" class="{% if request.resolver_match.url_name == 'assumptions' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700{% endif %} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
                             Assumptions
                         </a>

--- a/glidepath_app/templates/glidepath_app/fund_provider_detail.html
+++ b/glidepath_app/templates/glidepath_app/fund_provider_detail.html
@@ -1,0 +1,31 @@
+{% extends 'glidepath_app/base.html' %}
+{% block title %}Glidepath - {% if is_edit %}Edit{% else %}Add{% endif %} Provider{% endblock %}
+{% block content %}
+<div class="bg-white shadow rounded-lg p-8 max-w-2xl mx-auto">
+    <h1 class="text-2xl font-bold text-gray-900 mb-6">{% if is_edit %}Edit{% else %}Add{% endif %} Fund Provider</h1>
+
+    <form method="post" class="space-y-6">
+        {% csrf_token %}
+        {% for field in form %}
+        <div>
+            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ field.label }}</label>
+            {{ field }}
+            {% if field.help_text %}<p class="mt-1 text-xs text-gray-500">{{ field.help_text }}</p>{% endif %}
+            {% if field.errors %}<p class="mt-1 text-sm text-red-600">{{ field.errors.0 }}</p>{% endif %}
+        </div>
+        {% endfor %}
+        {% if form.non_field_errors %}
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">{{ form.non_field_errors }}</div>
+        {% endif %}
+
+        <div class="flex justify-end space-x-3 pt-4">
+            <a href="{% url 'virtual_funds' %}" class="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50">Cancel</a>
+            {% if is_admin %}
+            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700">Save</button>
+            {% else %}
+            <button type="button" disabled class="px-4 py-2 rounded-md text-sm font-medium text-gray-500 bg-gray-300 cursor-not-allowed">Save</button>
+            {% endif %}
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/glidepath_app/templates/glidepath_app/virtual_fund_detail.html
+++ b/glidepath_app/templates/glidepath_app/virtual_fund_detail.html
@@ -74,6 +74,7 @@
     const rows = document.getElementById('comp-rows');
     const addBtn = document.getElementById('add-comp-row');
     const totalEl = document.getElementById('comp-total');
+    if (!totalForms || !rows || !addBtn || !totalEl) return;  // bail if markup is missing
 
     function recalc() {
         let sum = 0;

--- a/glidepath_app/templates/glidepath_app/virtual_fund_detail.html
+++ b/glidepath_app/templates/glidepath_app/virtual_fund_detail.html
@@ -1,0 +1,105 @@
+{% extends 'glidepath_app/base.html' %}
+{% block title %}Glidepath - {% if is_edit %}Edit{% else %}Add{% endif %} Virtual Fund{% endblock %}
+{% block content %}
+<div class="bg-white shadow rounded-lg p-8 max-w-3xl mx-auto">
+    <h1 class="text-2xl font-bold text-gray-900 mb-6">{% if is_edit %}Edit{% else %}Add{% endif %} Virtual Fund</h1>
+
+    <form method="post" class="space-y-6">
+        {% csrf_token %}
+
+        {% for field in form %}
+        <div>
+            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ field.label }}</label>
+            {{ field }}
+            {% if field.help_text %}<p class="mt-1 text-xs text-gray-500">{{ field.help_text }}</p>{% endif %}
+            {% if field.errors %}<p class="mt-1 text-sm text-red-600">{{ field.errors.0 }}</p>{% endif %}
+        </div>
+        {% endfor %}
+
+        <!-- Composition -->
+        <div>
+            <div class="flex items-center justify-between mb-2">
+                <h2 class="text-lg font-semibold text-gray-900">Composition</h2>
+                <span class="text-sm">Total: <span id="comp-total" class="font-semibold">0</span>%</span>
+            </div>
+            {% if formset.non_form_errors %}
+            <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded mb-3 text-sm">{{ formset.non_form_errors }}</div>
+            {% endif %}
+            {{ formset.management_form }}
+            <table class="min-w-full border" id="comp-table">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Asset Category</th>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Percentage</th>
+                        <th class="px-3 py-2 text-center text-xs font-medium text-gray-500 uppercase">Remove</th>
+                    </tr>
+                </thead>
+                <tbody id="comp-rows">
+                    {% for cform in formset %}
+                    <tr class="comp-row border-t">
+                        {% for hidden in cform.hidden_fields %}{{ hidden }}{% endfor %}
+                        <td class="px-3 py-2">{{ cform.asset_category }}{% if cform.asset_category.errors %}<p class="text-xs text-red-600">{{ cform.asset_category.errors.0 }}</p>{% endif %}</td>
+                        <td class="px-3 py-2">{{ cform.percentage }}{% if cform.percentage.errors %}<p class="text-xs text-red-600">{{ cform.percentage.errors.0 }}</p>{% endif %}</td>
+                        <td class="px-3 py-2 text-center">{{ cform.DELETE }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <button type="button" id="add-comp-row" class="mt-3 text-indigo-600 hover:text-indigo-900 text-sm font-medium">+ Add category</button>
+            <p class="mt-1 text-xs text-gray-500">Percentages must sum to 100%.</p>
+        </div>
+
+        <div class="flex justify-end space-x-3 pt-4">
+            <a href="{% url 'virtual_funds' %}" class="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50">Cancel</a>
+            {% if is_admin %}
+            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700">Save</button>
+            {% else %}
+            <button type="button" disabled class="px-4 py-2 rounded-md text-sm font-medium text-gray-500 bg-gray-300 cursor-not-allowed">Save</button>
+            {% endif %}
+        </div>
+    </form>
+</div>
+
+<template id="empty-comp-row">
+    <tr class="comp-row border-t">
+        <td class="px-3 py-2">{{ formset.empty_form.asset_category }}</td>
+        <td class="px-3 py-2">{{ formset.empty_form.percentage }}</td>
+        <td class="px-3 py-2 text-center">{{ formset.empty_form.DELETE }}</td>
+    </tr>
+</template>
+
+<script>
+(function () {
+    const totalForms = document.getElementById('id_{{ formset.prefix }}-TOTAL_FORMS');
+    const rows = document.getElementById('comp-rows');
+    const addBtn = document.getElementById('add-comp-row');
+    const totalEl = document.getElementById('comp-total');
+
+    function recalc() {
+        let sum = 0;
+        document.querySelectorAll('.comp-row').forEach(function (row) {
+            const del = row.querySelector('input[name$="-DELETE"]');
+            if (del && del.checked) return;
+            const pct = row.querySelector('input[name$="-percentage"]');
+            if (pct && pct.value) sum += parseFloat(pct.value) || 0;
+        });
+        totalEl.textContent = (Math.round(sum * 100) / 100);
+        totalEl.className = Math.abs(sum - 100) < 0.005 ? 'font-semibold text-green-600' : 'font-semibold text-red-600';
+    }
+
+    addBtn.addEventListener('click', function () {
+        const idx = parseInt(totalForms.value, 10);
+        const html = document.getElementById('empty-comp-row').innerHTML.replace(/__prefix__/g, idx);
+        const tmp = document.createElement('tbody');
+        tmp.innerHTML = html.trim();
+        rows.appendChild(tmp.firstElementChild);
+        totalForms.value = idx + 1;
+        recalc();
+    });
+
+    rows.addEventListener('input', recalc);
+    rows.addEventListener('change', recalc);
+    recalc();
+})();
+</script>
+{% endblock %}

--- a/glidepath_app/templates/glidepath_app/virtual_funds.html
+++ b/glidepath_app/templates/glidepath_app/virtual_funds.html
@@ -104,7 +104,8 @@
 <script>
 function startRefresh(form) {
     var btn = form.querySelector('.refresh-btn');
-    if (!btn || btn.dataset.busy === '1') return false;  // prevent double submit
+    if (!btn) return true;  // markup drift: still allow the POST, just without busy UI
+    if (btn.dataset.busy === '1') return false;  // prevent double submit
     btn.dataset.busy = '1';
     // Disable after submission has been initiated so the POST still goes through.
     setTimeout(function () {

--- a/glidepath_app/templates/glidepath_app/virtual_funds.html
+++ b/glidepath_app/templates/glidepath_app/virtual_funds.html
@@ -31,10 +31,14 @@
             {% if is_admin %}
             <div class="flex items-center space-x-2">
                 {% if entry.provider.price_scraper %}
-                <form method="post" action="{% url 'refresh_provider_prices' entry.provider.id %}" class="inline">
-                    {% csrf_token %}
-                    <button type="submit" class="px-3 py-1 bg-purple-600 text-white rounded-md hover:bg-purple-700 text-sm">Refresh Prices</button>
-                </form>
+                    {% if entry.can_refresh %}
+                    <form method="post" action="{% url 'refresh_provider_prices' entry.provider.id %}" class="inline" onsubmit="return startRefresh(this)">
+                        {% csrf_token %}
+                        <button type="submit" class="refresh-btn px-3 py-1 bg-purple-600 text-white rounded-md hover:bg-purple-700 text-sm disabled:opacity-60 disabled:cursor-not-allowed">Refresh Prices</button>
+                    </form>
+                    {% else %}
+                    <button type="button" disabled title="Refreshed {{ entry.minutes_ago }} min ago — prices update infrequently" class="px-3 py-1 bg-gray-300 text-gray-500 rounded-md text-sm cursor-not-allowed">Refresh Prices</button>
+                    {% endif %}
                 {% endif %}
                 <a href="{% url 'fund_provider_edit' entry.provider.id %}" class="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm">Edit</a>
                 <form method="post" action="{% url 'delete_fund_provider' entry.provider.id %}" class="inline" onsubmit="return confirm('Delete this provider and all its virtual funds?');">
@@ -96,4 +100,18 @@
     <p class="text-gray-500">No fund providers yet.{% if is_admin %} Click "Add Provider" to create one.{% endif %}</p>
     {% endfor %}
 </div>
+
+<script>
+function startRefresh(form) {
+    var btn = form.querySelector('.refresh-btn');
+    if (!btn || btn.dataset.busy === '1') return false;  // prevent double submit
+    btn.dataset.busy = '1';
+    // Disable after submission has been initiated so the POST still goes through.
+    setTimeout(function () {
+        btn.disabled = true;
+        btn.textContent = 'Refreshing…';
+    }, 0);
+    return true;
+}
+</script>
 {% endblock %}

--- a/glidepath_app/templates/glidepath_app/virtual_funds.html
+++ b/glidepath_app/templates/glidepath_app/virtual_funds.html
@@ -17,6 +17,9 @@
     {% if refresh_error %}
     <div class="bg-red-50 border-l-4 border-red-400 p-4 mb-6"><p class="text-sm text-red-700">{{ refresh_error }}</p></div>
     {% endif %}
+    {% if refresh_info %}
+    <div class="bg-blue-50 border-l-4 border-blue-400 p-4 mb-6"><p class="text-sm text-blue-700">{{ refresh_info }}</p></div>
+    {% endif %}
 
     {% for entry in providers %}
     <div class="border border-gray-200 rounded-lg mb-8">

--- a/glidepath_app/templates/glidepath_app/virtual_funds.html
+++ b/glidepath_app/templates/glidepath_app/virtual_funds.html
@@ -1,0 +1,99 @@
+{% extends 'glidepath_app/base.html' %}
+{% block title %}Glidepath - Virtual Funds{% endblock %}
+{% block content %}
+<div class="bg-white shadow rounded-lg p-8">
+    <div class="flex items-center justify-between mb-6">
+        <h1 class="text-3xl font-bold text-gray-900">Virtual Funds</h1>
+        {% if is_admin %}
+        <a href="{% url 'fund_provider_add' %}" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 text-sm font-medium">
+            Add Provider
+        </a>
+        {% endif %}
+    </div>
+
+    {% if refresh_summary %}
+    <div class="bg-green-50 border-l-4 border-green-400 p-4 mb-6"><p class="text-sm text-green-700">{{ refresh_summary }}</p></div>
+    {% endif %}
+    {% if refresh_error %}
+    <div class="bg-red-50 border-l-4 border-red-400 p-4 mb-6"><p class="text-sm text-red-700">{{ refresh_error }}</p></div>
+    {% endif %}
+
+    {% for entry in providers %}
+    <div class="border border-gray-200 rounded-lg mb-8">
+        <div class="flex items-center justify-between bg-gray-50 px-5 py-3 rounded-t-lg">
+            <div>
+                <h2 class="text-xl font-semibold text-gray-900">{{ entry.provider.name }}</h2>
+                <p class="text-xs text-gray-500">
+                    slug: {{ entry.provider.slug }}
+                    {% if entry.provider.last_price_refresh %}· prices refreshed {{ entry.provider.last_price_refresh|date:"Y-m-d H:i" }} UTC{% else %}· prices never refreshed{% endif %}
+                </p>
+            </div>
+            {% if is_admin %}
+            <div class="flex items-center space-x-2">
+                {% if entry.provider.price_scraper %}
+                <form method="post" action="{% url 'refresh_provider_prices' entry.provider.id %}" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="px-3 py-1 bg-purple-600 text-white rounded-md hover:bg-purple-700 text-sm">Refresh Prices</button>
+                </form>
+                {% endif %}
+                <a href="{% url 'fund_provider_edit' entry.provider.id %}" class="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm">Edit</a>
+                <form method="post" action="{% url 'delete_fund_provider' entry.provider.id %}" class="inline" onsubmit="return confirm('Delete this provider and all its virtual funds?');">
+                    {% csrf_token %}
+                    <button type="submit" class="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm">Delete</button>
+                </form>
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="p-5">
+            <div class="flex justify-between items-center mb-3">
+                <h3 class="text-sm font-medium text-gray-700 uppercase">Virtual Funds</h3>
+                {% if is_admin %}
+                <a href="{% url 'virtual_fund_add' %}" class="text-indigo-600 hover:text-indigo-900 text-sm font-medium">+ Add Fund</a>
+                {% endif %}
+            </div>
+            {% if entry.funds %}
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 border">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Slug</th>
+                            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Unit Price</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Price As Of</th>
+                            <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Active</th>
+                            {% if is_admin %}<th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>{% endif %}
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        {% for fund in entry.funds %}
+                        <tr>
+                            <td class="px-4 py-2 text-sm text-gray-900">{{ fund.name }}</td>
+                            <td class="px-4 py-2 text-sm text-gray-500">{{ fund.slug }}</td>
+                            <td class="px-4 py-2 text-sm text-gray-900 text-right">{% if fund.unit_price is not None %}{{ fund.unit_price }}{% else %}&mdash;{% endif %}</td>
+                            <td class="px-4 py-2 text-sm text-gray-500">{{ fund.price_as_of|default:"&mdash;" }}</td>
+                            <td class="px-4 py-2 text-sm text-center">{% if fund.is_active %}<span class="text-green-600">Yes</span>{% else %}<span class="text-gray-400">No</span>{% endif %}</td>
+                            {% if is_admin %}
+                            <td class="px-4 py-2 text-right text-sm space-x-2 whitespace-nowrap">
+                                <a href="{% url 'virtual_fund_edit' fund.id %}" class="text-blue-600 hover:text-blue-900">Edit</a>
+                                <form method="post" action="{% url 'delete_virtual_fund' fund.id %}" class="inline" onsubmit="return confirm('Delete this virtual fund?');">
+                                    {% csrf_token %}
+                                    <button type="submit" class="text-red-600 hover:text-red-900">Delete</button>
+                                </form>
+                            </td>
+                            {% endif %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-gray-500 text-sm">No virtual funds for this provider yet.</p>
+            {% endif %}
+        </div>
+    </div>
+    {% empty %}
+    <p class="text-gray-500">No fund providers yet.{% if is_admin %} Click "Add Provider" to create one.{% endif %}</p>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/glidepath_app/tests.py
+++ b/glidepath_app/tests.py
@@ -16,7 +16,8 @@ from .services import export_glidepath_rules, import_glidepath_rules
 from .account_services import (
     parse_nysaves_csv, get_portfolio_analysis, resolve_position_asset_categories,
 )
-from .forms import PortfolioForm
+from .forms import PortfolioForm, VirtualFundCompositionFormSet
+from .models import VirtualFundComposition
 from .education_projection import (
     calculate_education_projection, calculate_required_contribution,
 )
@@ -490,3 +491,71 @@ class AccessControlTests(TestCase):
         self.assertEqual(
             self.client.get(reverse("edit_portfolio", args=[self.portfolio.id])).status_code, 200
         )
+
+
+class VirtualFundAdminTests(TestCase):
+    """Admin CRUD for providers/funds/compositions + price refresh."""
+
+    def setUp(self):
+        self.admin = User.objects.create(username="adm", email="adm@example.com", role=0)
+        self.provider = FundProvider.objects.get(slug="nysaves")  # seeded
+
+    def _login(self, admin=True):
+        session = self.client.session
+        session["user_id"] = str(self.admin.id)
+        if admin:
+            session["is_admin"] = True
+        session.save()
+
+    def test_list_view_renders(self):
+        self._login(admin=False)
+        resp = self.client.get(reverse("virtual_funds"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "NY 529 Direct Plan")
+
+    def test_non_admin_cannot_create_provider(self):
+        self._login(admin=False)
+        resp = self.client.post(reverse("fund_provider_add"),
+                                {"name": "X", "slug": "x", "price_source_url": "",
+                                 "price_scraper": "", "notes": ""})
+        self.assertEqual(resp.status_code, 403)
+        self.assertFalse(FundProvider.objects.filter(slug="x").exists())
+
+    def test_admin_creates_provider(self):
+        self._login()
+        resp = self.client.post(reverse("fund_provider_add"),
+                                {"name": "Vanguard 529", "slug": "vanguard-529",
+                                 "price_source_url": "", "price_scraper": "", "notes": ""})
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(FundProvider.objects.filter(slug="vanguard-529").exists())
+
+    def _composition_data(self, p1, p2):
+        cat1 = AssetCategory.objects.get(name="US Total Market", asset_class__name="Stocks")
+        cat2 = AssetCategory.objects.get(name="International Market", asset_class__name="Stocks")
+        return {
+            "composition-TOTAL_FORMS": "2", "composition-INITIAL_FORMS": "0",
+            "composition-MIN_NUM_FORMS": "0", "composition-MAX_NUM_FORMS": "1000",
+            "composition-0-asset_category": str(cat1.id), "composition-0-percentage": str(p1), "composition-0-id": "",
+            "composition-1-asset_category": str(cat2.id), "composition-1-percentage": str(p2), "composition-1-id": "",
+        }
+
+    def test_composition_formset_requires_100(self):
+        fund = VirtualFund.objects.create(provider=self.provider, name="T", slug="t-fund")
+        self.assertTrue(VirtualFundCompositionFormSet(self._composition_data(60, 40), instance=fund).is_valid())
+        bad = VirtualFundCompositionFormSet(self._composition_data(60, 30), instance=fund)
+        self.assertFalse(bad.is_valid())
+        self.assertIn("100%", str(bad.non_form_errors()))
+
+    def test_refresh_provider_prices(self):
+        from datetime import date
+        feed = {"Growth Stock Index Portfolio": (Decimal("23.45"), date(2026, 6, 26))}
+        self._login()
+        with mock.patch.dict(scraper_service.SCRAPERS, {"nysaves": lambda p: feed}):
+            resp = self.client.post(reverse("refresh_provider_prices", args=[self.provider.id]))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(VirtualFund.objects.get(slug="growth-stock-index").unit_price, Decimal("23.45"))
+
+    def test_non_admin_cannot_refresh(self):
+        self._login(admin=False)
+        resp = self.client.post(reverse("refresh_provider_prices", args=[self.provider.id]))
+        self.assertEqual(resp.status_code, 403)

--- a/glidepath_app/tests.py
+++ b/glidepath_app/tests.py
@@ -568,12 +568,16 @@ class VirtualFundAdminTests(TestCase):
         self._login()
         feed = {"Growth Stock Index Portfolio": (Decimal("99.99"), date(2026, 6, 26))}
         with mock.patch.dict(scraper_service.SCRAPERS, {"nysaves": lambda p: feed}):
-            resp = self.client.post(reverse("refresh_provider_prices", args=[self.provider.id]))
-        self.assertEqual(resp.status_code, 302)
-        # Throttled: price was NOT re-fetched.
+            resp = self.client.post(
+                reverse("refresh_provider_prices", args=[self.provider.id]), follow=True
+            )
+        # Throttled: price was NOT re-fetched, and the notice is informational (blue),
+        # not a green success banner.
         self.assertNotEqual(
             VirtualFund.objects.get(slug="growth-stock-index").unit_price, Decimal("99.99")
         )
+        self.assertContains(resp, "try again in about")
+        self.assertContains(resp, "text-blue-700")
 
     def test_zero_update_refresh_does_not_start_cooldown(self):
         from datetime import date

--- a/glidepath_app/tests.py
+++ b/glidepath_app/tests.py
@@ -559,3 +559,30 @@ class VirtualFundAdminTests(TestCase):
         self._login(admin=False)
         resp = self.client.post(reverse("refresh_provider_prices", args=[self.provider.id]))
         self.assertEqual(resp.status_code, 403)
+
+    def test_refresh_throttled_within_cooldown(self):
+        from datetime import date
+        from django.utils import timezone
+        self.provider.last_price_refresh = timezone.now()  # just refreshed
+        self.provider.save(update_fields=["last_price_refresh"])
+        self._login()
+        feed = {"Growth Stock Index Portfolio": (Decimal("99.99"), date(2026, 6, 26))}
+        with mock.patch.dict(scraper_service.SCRAPERS, {"nysaves": lambda p: feed}):
+            resp = self.client.post(reverse("refresh_provider_prices", args=[self.provider.id]))
+        self.assertEqual(resp.status_code, 302)
+        # Throttled: price was NOT re-fetched.
+        self.assertNotEqual(
+            VirtualFund.objects.get(slug="growth-stock-index").unit_price, Decimal("99.99")
+        )
+
+    def test_list_disables_refresh_within_cooldown(self):
+        from django.utils import timezone
+        self._login()
+        # No recent refresh -> enabled form present.
+        resp = self.client.get(reverse("virtual_funds"))
+        self.assertContains(resp, "startRefresh(this)")
+        # Recent refresh -> disabled button with tooltip.
+        self.provider.last_price_refresh = timezone.now()
+        self.provider.save(update_fields=["last_price_refresh"])
+        resp = self.client.get(reverse("virtual_funds"))
+        self.assertContains(resp, "prices update infrequently")

--- a/glidepath_app/tests.py
+++ b/glidepath_app/tests.py
@@ -596,3 +596,45 @@ class VirtualFundAdminTests(TestCase):
         self.provider.save(update_fields=["last_price_refresh"])
         resp = self.client.get(reverse("virtual_funds"))
         self.assertContains(resp, "prices update infrequently")
+
+    def _vfund_post(self, p1, p2):
+        cat1 = AssetCategory.objects.get(name="US Total Market", asset_class__name="Stocks")
+        cat2 = AssetCategory.objects.get(name="International Market", asset_class__name="Stocks")
+        return {
+            "provider": str(self.provider.id), "name": "Test Fund", "slug": "test-fund",
+            "unit_price": "", "price_as_of": "", "is_active": "on", "notes": "",
+            "composition-TOTAL_FORMS": "2", "composition-INITIAL_FORMS": "0",
+            "composition-MIN_NUM_FORMS": "0", "composition-MAX_NUM_FORMS": "1000",
+            "composition-0-asset_category": str(cat1.id), "composition-0-percentage": str(p1), "composition-0-id": "",
+            "composition-1-asset_category": str(cat2.id), "composition-1-percentage": str(p2), "composition-1-id": "",
+        }
+
+    def test_create_with_invalid_composition_saves_nothing(self):
+        self._login()
+        before = VirtualFund.objects.count()
+        resp = self.client.post(reverse("virtual_fund_add"), self._vfund_post(60, 30))  # sums to 90
+        self.assertEqual(resp.status_code, 200)  # re-rendered with error, not redirect
+        self.assertContains(resp, "100%")
+        self.assertEqual(VirtualFund.objects.count(), before)  # no orphan fund created
+
+    def test_create_with_valid_composition_saves(self):
+        self._login()
+        resp = self.client.post(reverse("virtual_fund_add"), self._vfund_post(60, 40))
+        self.assertEqual(resp.status_code, 302)
+        fund = VirtualFund.objects.get(slug="test-fund")
+        self.assertEqual(fund.composition.count(), 2)
+
+    def test_zero_update_refresh_shows_error_not_success(self):
+        from datetime import date
+        feed = {"Nonexistent Portfolio": (Decimal("1.00"), date(2026, 6, 26))}
+        self._login()
+        with mock.patch.dict(scraper_service.SCRAPERS, {"nysaves": lambda p: feed}):
+            resp = self.client.post(
+                reverse("refresh_provider_prices", args=[self.provider.id]), follow=True
+            )
+        self.assertContains(resp, "no prices were updated")
+
+    def test_non_admin_cannot_get_detail_forms(self):
+        self._login(admin=False)
+        self.assertEqual(self.client.get(reverse("fund_provider_add")).status_code, 403)
+        self.assertEqual(self.client.get(reverse("virtual_fund_add")).status_code, 403)

--- a/glidepath_app/tests.py
+++ b/glidepath_app/tests.py
@@ -575,6 +575,16 @@ class VirtualFundAdminTests(TestCase):
             VirtualFund.objects.get(slug="growth-stock-index").unit_price, Decimal("99.99")
         )
 
+    def test_zero_update_refresh_does_not_start_cooldown(self):
+        from datetime import date
+        # A scraped name that matches no seeded fund -> updated 0 -> no timestamp.
+        feed = {"Nonexistent Portfolio": (Decimal("1.00"), date(2026, 6, 26))}
+        with mock.patch.dict(scraper_service.SCRAPERS, {"nysaves": lambda p: feed}):
+            result = scraper_service.refresh_virtual_fund_prices("nysaves")
+        self.assertEqual(result["updated"], 0)
+        self.provider.refresh_from_db()
+        self.assertIsNone(self.provider.last_price_refresh)
+
     def test_list_disables_refresh_within_cooldown(self):
         from django.utils import timezone
         self._login()

--- a/glidepath_app/views.py
+++ b/glidepath_app/views.py
@@ -2114,18 +2114,33 @@ def modeling_view(request):
 # Virtual fund / provider administration (admin-gated)
 # ---------------------------------------------------------------------------
 
+PRICE_REFRESH_COOLDOWN_SECONDS = 3600  # prices update infrequently; throttle re-fetches
+
+
 def virtual_funds_view(request):
     """List fund providers and their virtual funds. Editing is admin-only."""
+    from django.utils import timezone
+
     is_admin = request.session.get('is_admin', False)
 
     refresh_summary = request.session.pop('vf_refresh_summary', None)
     refresh_error = request.session.pop('vf_refresh_error', None)
 
+    now = timezone.now()
     providers = []
     for provider in FundProvider.objects.prefetch_related('virtual_funds').all():
+        # A successful refresh stamps last_price_refresh; throttle within the cooldown.
+        can_refresh = True
+        minutes_ago = None
+        if provider.last_price_refresh:
+            elapsed = (now - provider.last_price_refresh).total_seconds()
+            minutes_ago = int(elapsed // 60)
+            can_refresh = elapsed >= PRICE_REFRESH_COOLDOWN_SECONDS
         providers.append({
             'provider': provider,
             'funds': provider.virtual_funds.all(),
+            'can_refresh': can_refresh,
+            'minutes_ago': minutes_ago,
         })
 
     context = {
@@ -2211,9 +2226,24 @@ def delete_virtual_fund(request, fund_id):
 @require_POST
 def refresh_provider_prices(request, provider_id):
     """Manually trigger a price refresh for a provider's virtual funds."""
+    from django.utils import timezone
+
     provider = FundProvider.objects.filter(id=provider_id).first()
     if provider is None:
         return redirect('virtual_funds')
+
+    # Throttle: a successful refresh stamps last_price_refresh (failures don't), so
+    # this blocks re-polling within the cooldown without blocking retries of failures.
+    if provider.last_price_refresh:
+        elapsed = (timezone.now() - provider.last_price_refresh).total_seconds()
+        if elapsed < PRICE_REFRESH_COOLDOWN_SECONDS:
+            mins = int((PRICE_REFRESH_COOLDOWN_SECONDS - elapsed) // 60) + 1
+            request.session['vf_refresh_summary'] = (
+                f"{provider.name}: prices were refreshed {int(elapsed // 60)} min ago. "
+                f"They update infrequently — try again in about {mins} min."
+            )
+            return redirect('virtual_funds')
+
     try:
         result = refresh_virtual_fund_prices(provider.slug)
         summary = f"{provider.name}: updated {result['updated']} of {result['scraped_count']} scraped fund(s)."

--- a/glidepath_app/views.py
+++ b/glidepath_app/views.py
@@ -2129,7 +2129,7 @@ def virtual_funds_view(request):
     now = timezone.now()
     providers = []
     for provider in FundProvider.objects.prefetch_related('virtual_funds').all():
-        # A successful refresh stamps last_price_refresh; throttle within the cooldown.
+        # last_price_refresh is stamped only when prices were updated; throttle within the cooldown.
         can_refresh = True
         minutes_ago = None
         if provider.last_price_refresh:
@@ -2232,8 +2232,8 @@ def refresh_provider_prices(request, provider_id):
     if provider is None:
         return redirect('virtual_funds')
 
-    # Throttle: a successful refresh stamps last_price_refresh (failures don't), so
-    # this blocks re-polling within the cooldown without blocking retries of failures.
+    # Throttle: last_price_refresh is stamped only when prices were retrieved, so this
+    # blocks re-polling within the cooldown without blocking retries of failed/empty fetches.
     if provider.last_price_refresh:
         elapsed = (timezone.now() - provider.last_price_refresh).total_seconds()
         if elapsed < PRICE_REFRESH_COOLDOWN_SECONDS:

--- a/glidepath_app/views.py
+++ b/glidepath_app/views.py
@@ -1,7 +1,11 @@
 import json
 import csv
 import io
+import logging
 
+import requests
+
+from django.db import transaction
 from django.http import HttpResponse, JsonResponse, HttpResponseForbidden
 from django.shortcuts import render, redirect
 from django.views.decorators.http import require_POST
@@ -15,6 +19,8 @@ from .ticker_service import query_ticker as query_ticker_service
 from .account_services import import_fidelity_csv, import_etrade_csv, parse_nysaves_csv, get_portfolio_analysis, calculate_rebalance_recommendations
 from .scraper_service import refresh_virtual_fund_prices
 from .decorators import admin_required
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_COLORS = [
     "#FF6384",
@@ -2152,16 +2158,14 @@ def virtual_funds_view(request):
     return render(request, 'glidepath_app/virtual_funds.html', context)
 
 
+@admin_required
 def fund_provider_detail(request, provider_id=None):
-    """Add or edit a fund provider."""
-    is_admin = request.session.get('is_admin', False)
+    """Add or edit a fund provider (admin only)."""
     provider = FundProvider.objects.filter(id=provider_id).first() if provider_id else None
     if provider_id and provider is None:
         return redirect('virtual_funds')
 
     if request.method == 'POST':
-        if not is_admin:
-            return HttpResponseForbidden("Administrator privileges required.")
         form = FundProviderForm(request.POST, instance=provider)
         if form.is_valid():
             form.save()
@@ -2169,7 +2173,7 @@ def fund_provider_detail(request, provider_id=None):
     else:
         form = FundProviderForm(instance=provider)
 
-    context = {'form': form, 'provider': provider, 'is_edit': provider is not None, 'is_admin': is_admin}
+    context = {'form': form, 'provider': provider, 'is_edit': provider is not None, 'is_admin': True}
     return render(request, 'glidepath_app/fund_provider_detail.html', context)
 
 
@@ -2181,25 +2185,26 @@ def delete_fund_provider(request, provider_id):
     return redirect('virtual_funds')
 
 
+@admin_required
 def virtual_fund_detail(request, fund_id=None):
-    """Add or edit a virtual fund, including its composition breakdown."""
-    is_admin = request.session.get('is_admin', False)
+    """Add or edit a virtual fund, including its composition breakdown (admin only)."""
     fund = VirtualFund.objects.filter(id=fund_id).first() if fund_id else None
     if fund_id and fund is None:
         return redirect('virtual_funds')
 
     if request.method == 'POST':
-        if not is_admin:
-            return HttpResponseForbidden("Administrator privileges required.")
         form = VirtualFundForm(request.POST, instance=fund)
-        formset = VirtualFundCompositionFormSet(request.POST, instance=fund)
-        if form.is_valid():
-            new_fund = form.save()
-            # Re-bind the formset to the (possibly newly created) fund instance.
-            formset = VirtualFundCompositionFormSet(request.POST, instance=new_fund)
-            if formset.is_valid():
+        # Bind to the existing fund, or a transient instance for create, so the
+        # composition can be validated BEFORE anything is written.
+        formset = VirtualFundCompositionFormSet(request.POST, instance=fund or VirtualFund())
+        if form.is_valid() and formset.is_valid():
+            # Atomic so an invalid composition never leaves an orphaned fund, and a
+            # later DB error rolls back the fund's field changes too.
+            with transaction.atomic():
+                saved_fund = form.save()
+                formset.instance = saved_fund
                 formset.save()
-                return redirect('virtual_funds')
+            return redirect('virtual_funds')
     else:
         form = VirtualFundForm(instance=fund)
         formset = VirtualFundCompositionFormSet(instance=fund)
@@ -2209,7 +2214,7 @@ def virtual_fund_detail(request, fund_id=None):
         'formset': formset,
         'fund': fund,
         'is_edit': fund is not None,
-        'is_admin': is_admin,
+        'is_admin': True,
     }
     return render(request, 'glidepath_app/virtual_fund_detail.html', context)
 
@@ -2246,12 +2251,26 @@ def refresh_provider_prices(request, provider_id):
 
     try:
         result = refresh_virtual_fund_prices(provider.slug)
-        summary = f"{provider.name}: updated {result['updated']} of {result['scraped_count']} scraped fund(s)."
-        if result['not_updated']:
-            summary += f" No price for {len(result['not_updated'])} fund(s)."
-        if result['unmatched_scraped']:
-            summary += f" {len(result['unmatched_scraped'])} scraped row(s) matched no fund."
-        request.session['vf_refresh_summary'] = summary
-    except Exception as exc:
+    except (ValueError, requests.RequestException) as exc:
+        logger.exception("Price refresh failed for provider %s", provider.slug)
         request.session['vf_refresh_error'] = f"Price refresh failed: {exc}"
+        return redirect('virtual_funds')
+
+    if result['updated'] == 0:
+        # Nothing was retrieved/applied — surface as an error, not a green success.
+        detail = f"returned {result['scraped_count']} row(s) but none matched a seeded fund"
+        if result['scraped_count'] == 0:
+            detail = "returned no prices (the feed may have changed or be unavailable)"
+        request.session['vf_refresh_error'] = (
+            f"{provider.name}: no prices were updated — the scraper {detail}. "
+            "Check fund names against the provider, then try again."
+        )
+        return redirect('virtual_funds')
+
+    summary = f"{provider.name}: updated {result['updated']} of {result['scraped_count']} scraped fund(s)."
+    if result['not_updated']:
+        summary += f" No price for {len(result['not_updated'])} fund(s)."
+    if result['unmatched_scraped']:
+        summary += f" {len(result['unmatched_scraped'])} scraped row(s) matched no fund."
+    request.session['vf_refresh_summary'] = summary
     return redirect('virtual_funds')

--- a/glidepath_app/views.py
+++ b/glidepath_app/views.py
@@ -2131,6 +2131,7 @@ def virtual_funds_view(request):
 
     refresh_summary = request.session.pop('vf_refresh_summary', None)
     refresh_error = request.session.pop('vf_refresh_error', None)
+    refresh_info = request.session.pop('vf_refresh_info', None)
 
     now = timezone.now()
     providers = []
@@ -2154,6 +2155,7 @@ def virtual_funds_view(request):
         'is_admin': is_admin,
         'refresh_summary': refresh_summary,
         'refresh_error': refresh_error,
+        'refresh_info': refresh_info,
     }
     return render(request, 'glidepath_app/virtual_funds.html', context)
 
@@ -2243,7 +2245,7 @@ def refresh_provider_prices(request, provider_id):
         elapsed = (timezone.now() - provider.last_price_refresh).total_seconds()
         if elapsed < PRICE_REFRESH_COOLDOWN_SECONDS:
             mins = int((PRICE_REFRESH_COOLDOWN_SECONDS - elapsed) // 60) + 1
-            request.session['vf_refresh_summary'] = (
+            request.session['vf_refresh_info'] = (
                 f"{provider.name}: prices were refreshed {int(elapsed // 60)} min ago. "
                 f"They update infrequently — try again in about {mins} min."
             )

--- a/glidepath_app/views.py
+++ b/glidepath_app/views.py
@@ -8,11 +8,12 @@ from django.views.decorators.http import require_POST
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.contrib.auth.hashers import check_password
 
-from .forms import GlidepathRuleUploadForm, APISettingsForm, FundForm, UserForm, IdentityProviderForm, AccountUploadForm, PortfolioForm, AssumptionUploadForm, SessionSettingsForm
-from .models import GlidepathRule, RuleSet, APISettings, Fund, AssetCategory, User, IdentityProvider, AccountUpload, AccountPosition, Portfolio, PortfolioItem, AssumptionUpload, AssumptionData, SessionSettings
+from .forms import GlidepathRuleUploadForm, APISettingsForm, FundForm, UserForm, IdentityProviderForm, AccountUploadForm, PortfolioForm, AssumptionUploadForm, SessionSettingsForm, FundProviderForm, VirtualFundForm, VirtualFundCompositionFormSet
+from .models import GlidepathRule, RuleSet, APISettings, Fund, AssetCategory, User, IdentityProvider, AccountUpload, AccountPosition, Portfolio, PortfolioItem, AssumptionUpload, AssumptionData, SessionSettings, FundProvider, VirtualFund
 from .services import export_glidepath_rules, import_glidepath_rules, import_blackrock_assumptions
 from .ticker_service import query_ticker as query_ticker_service
 from .account_services import import_fidelity_csv, import_etrade_csv, parse_nysaves_csv, get_portfolio_analysis, calculate_rebalance_recommendations
+from .scraper_service import refresh_virtual_fund_prices
 from .decorators import admin_required
 
 DEFAULT_COLORS = [
@@ -2107,3 +2108,120 @@ def modeling_view(request):
     }
 
     return render(request, 'glidepath_app/modeling.html', context)
+
+
+# ---------------------------------------------------------------------------
+# Virtual fund / provider administration (admin-gated)
+# ---------------------------------------------------------------------------
+
+def virtual_funds_view(request):
+    """List fund providers and their virtual funds. Editing is admin-only."""
+    is_admin = request.session.get('is_admin', False)
+
+    refresh_summary = request.session.pop('vf_refresh_summary', None)
+    refresh_error = request.session.pop('vf_refresh_error', None)
+
+    providers = []
+    for provider in FundProvider.objects.prefetch_related('virtual_funds').all():
+        providers.append({
+            'provider': provider,
+            'funds': provider.virtual_funds.all(),
+        })
+
+    context = {
+        'providers': providers,
+        'is_admin': is_admin,
+        'refresh_summary': refresh_summary,
+        'refresh_error': refresh_error,
+    }
+    return render(request, 'glidepath_app/virtual_funds.html', context)
+
+
+def fund_provider_detail(request, provider_id=None):
+    """Add or edit a fund provider."""
+    is_admin = request.session.get('is_admin', False)
+    provider = FundProvider.objects.filter(id=provider_id).first() if provider_id else None
+    if provider_id and provider is None:
+        return redirect('virtual_funds')
+
+    if request.method == 'POST':
+        if not is_admin:
+            return HttpResponseForbidden("Administrator privileges required.")
+        form = FundProviderForm(request.POST, instance=provider)
+        if form.is_valid():
+            form.save()
+            return redirect('virtual_funds')
+    else:
+        form = FundProviderForm(instance=provider)
+
+    context = {'form': form, 'provider': provider, 'is_edit': provider is not None, 'is_admin': is_admin}
+    return render(request, 'glidepath_app/fund_provider_detail.html', context)
+
+
+@admin_required
+@require_POST
+def delete_fund_provider(request, provider_id):
+    """Delete a fund provider (cascades to its virtual funds)."""
+    FundProvider.objects.filter(id=provider_id).delete()
+    return redirect('virtual_funds')
+
+
+def virtual_fund_detail(request, fund_id=None):
+    """Add or edit a virtual fund, including its composition breakdown."""
+    is_admin = request.session.get('is_admin', False)
+    fund = VirtualFund.objects.filter(id=fund_id).first() if fund_id else None
+    if fund_id and fund is None:
+        return redirect('virtual_funds')
+
+    if request.method == 'POST':
+        if not is_admin:
+            return HttpResponseForbidden("Administrator privileges required.")
+        form = VirtualFundForm(request.POST, instance=fund)
+        formset = VirtualFundCompositionFormSet(request.POST, instance=fund)
+        if form.is_valid():
+            new_fund = form.save()
+            # Re-bind the formset to the (possibly newly created) fund instance.
+            formset = VirtualFundCompositionFormSet(request.POST, instance=new_fund)
+            if formset.is_valid():
+                formset.save()
+                return redirect('virtual_funds')
+    else:
+        form = VirtualFundForm(instance=fund)
+        formset = VirtualFundCompositionFormSet(instance=fund)
+
+    context = {
+        'form': form,
+        'formset': formset,
+        'fund': fund,
+        'is_edit': fund is not None,
+        'is_admin': is_admin,
+    }
+    return render(request, 'glidepath_app/virtual_fund_detail.html', context)
+
+
+@admin_required
+@require_POST
+def delete_virtual_fund(request, fund_id):
+    """Delete a virtual fund (cascades to its composition)."""
+    VirtualFund.objects.filter(id=fund_id).delete()
+    return redirect('virtual_funds')
+
+
+@admin_required
+@require_POST
+def refresh_provider_prices(request, provider_id):
+    """Manually trigger a price refresh for a provider's virtual funds."""
+    provider = FundProvider.objects.filter(id=provider_id).first()
+    if provider is None:
+        return redirect('virtual_funds')
+    try:
+        result = refresh_virtual_fund_prices(provider.slug)
+        summary = f"{provider.name}: updated {result['updated']} of {result['scraped_count']} scraped fund(s)."
+        if result['not_updated']:
+            summary += f" No price for {len(result['not_updated'])} fund(s)."
+        if result['unmatched_scraped']:
+            summary += f" {len(result['unmatched_scraped'])} scraped row(s) matched no fund."
+        request.session['vf_refresh_summary'] = summary
+    except Exception as exc:
+        request.session['vf_refresh_error'] = f"Price refresh failed: {exc}"
+    return redirect('virtual_funds')

--- a/glidepath_project/urls.py
+++ b/glidepath_project/urls.py
@@ -33,6 +33,12 @@ from glidepath_app.views import (
     delete_identity_provider,
     download_funds_csv,
     upload_funds_csv,
+    virtual_funds_view,
+    fund_provider_detail,
+    delete_fund_provider,
+    virtual_fund_detail,
+    delete_virtual_fund,
+    refresh_provider_prices,
 )
 
 urlpatterns = [
@@ -45,6 +51,14 @@ urlpatterns = [
     path('funds/', funds_view, name='funds'),
     path('funds/detail/', fund_detail, name='fund_detail'),
     path('funds/delete/<int:fund_id>/', delete_fund, name='delete_fund'),
+    path('virtual-funds/', virtual_funds_view, name='virtual_funds'),
+    path('virtual-funds/providers/add/', fund_provider_detail, name='fund_provider_add'),
+    path('virtual-funds/providers/<uuid:provider_id>/edit/', fund_provider_detail, name='fund_provider_edit'),
+    path('virtual-funds/providers/<uuid:provider_id>/delete/', delete_fund_provider, name='delete_fund_provider'),
+    path('virtual-funds/providers/<uuid:provider_id>/refresh/', refresh_provider_prices, name='refresh_provider_prices'),
+    path('virtual-funds/funds/add/', virtual_fund_detail, name='virtual_fund_add'),
+    path('virtual-funds/funds/<uuid:fund_id>/edit/', virtual_fund_detail, name='virtual_fund_edit'),
+    path('virtual-funds/funds/<uuid:fund_id>/delete/', delete_virtual_fund, name='delete_virtual_fund'),
     path('accounts/', accounts_view, name='accounts'),
     path('accounts/nysaves-template.csv', nysaves_csv_template, name='nysaves_csv_template'),
     path('accounts/upload/<uuid:upload_id>/', view_account_upload, name='view_account_upload'),


### PR DESCRIPTION
Custom admin pages for managing virtual funds (529 portfolios), gated behind the app's Administrator role — mirroring the existing funds/settings CRUD conventions (no Django admin).

## What's included
- **Virtual Funds page** (new nav entry): each provider with its funds, unit prices, and last-refresh status. Read-only for everyone; edit/delete/refresh controls show only to admins.
- **FundProvider** add / edit / delete.
- **VirtualFund** add / edit / delete with an **inline composition editor** — percentages validated server-side to sum to 100% (`BaseCompositionFormSet`), plus a live running-total indicator and add-row in the UI.
- **"Refresh Prices"** button per provider → `refresh_virtual_fund_prices()`, with a result summary surfaced via session.
- All mutations 403 for non-admins (`@admin_required`/`@require_POST` or inline `is_admin` checks).

## Tests
40 tests green. New: list renders, non-admin create/refresh → 403, admin creates provider, composition formset rejects ≠100%, refresh updates prices. Both add-form templates also smoke-rendered (200). No model changes → no migrations.

## Not included (deferred follow-ups)
- Education ruleset creation via UI + example seed (next branch)
- Target Enrollment fund seeding; Monte Carlo for education

🤖 Generated with [Claude Code](https://claude.com/claude-code)